### PR TITLE
Added cname file for proper configuation with custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+sodium.space


### PR DESCRIPTION
This is necessary for having a custom domain point to `sodium-dtr.github.io`

See https://help.github.com/articles/adding-a-cname-file-to-your-repository/
